### PR TITLE
Alamb/parse procedure

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2115,13 +2115,19 @@ impl fmt::Display for Statement {
             } => {
                 write!(
                     f,
-                    "CREATE {or_alter}PROCEDURE {name} {params}AS BEGIN {body} END",
+                    "CREATE {or_alter}PROCEDURE {name}",
                     or_alter = if *or_alter { "OR ALTER " } else { "" },
-                    name = name,
-                    params = match params {
-                        Some(p) if !p.is_empty() => format!("({}) ", display_comma_separated(p)),
-                        _ => "".to_string(),
-                    },
+                    name = name
+                )?;
+
+                if let Some(p) = params {
+                    if !p.is_empty() {
+                        write!(f, " ({})", display_comma_separated(p))?;
+                    }
+                }
+                write!(
+                    f,
+                    " AS BEGIN {body} END",
                     body = display_separated(body, ",")
                 )
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -225,7 +225,7 @@ impl<'a> Parser<'a> {
     /// let dialect = GenericDialect{};
     /// let statements = Parser::new(&dialect)
     ///   .try_with_sql("SELECT * FROM foo")?
-    ///   .parse_statements(false)?;
+    ///   .parse_statements()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -254,7 +254,7 @@ impl<'a> Parser<'a> {
     /// let result = Parser::new(&dialect)
     ///   .with_recursion_limit(1)
     ///   .try_with_sql("SELECT * FROM foo WHERE (a OR (b OR (c OR d)))")?
-    ///   .parse_statements(false);
+    ///   .parse_statements();
     ///   assert_eq!(result, Err(ParserError::RecursionLimitExceeded));
     /// # Ok(())
     /// # }
@@ -279,7 +279,7 @@ impl<'a> Parser<'a> {
     /// let result = Parser::new(&dialect)
     ///   .with_options(ParserOptions { trailing_commas: true })
     ///   .try_with_sql("SELECT a, b, COUNT(*), FROM foo GROUP BY a, b,")?
-    ///   .parse_statements(false);
+    ///   .parse_statements();
     ///   assert!(matches!(result, Ok(_)));
     /// # Ok(())
     /// # }
@@ -332,12 +332,12 @@ impl<'a> Parser<'a> {
     /// let statements = Parser::new(&dialect)
     ///   // Parse a SQL string with 2 separate statements
     ///   .try_with_sql("SELECT * FROM foo; SELECT * FROM bar;")?
-    ///   .parse_statements(false)?;
+    ///   .parse_statements()?;
     /// assert_eq!(statements.len(), 2);
     /// # Ok(())
     /// # }
     /// ```
-    pub fn parse_statements(&mut self, break_on_end: bool) -> Result<Vec<Statement>, ParserError> {
+    pub fn parse_statements(&mut self) -> Result<Vec<Statement>, ParserError> {
         let mut stmts = Vec::new();
         let mut expecting_statement_delimiter = false;
         loop {
@@ -346,15 +346,12 @@ impl<'a> Parser<'a> {
                 expecting_statement_delimiter = false;
             }
 
-            if self.peek_token() == Token::EOF {
-                break;
-            }
-            if let true = break_on_end {
-                if let Token::Word(word) = self.peek_token().token {
-                    if word.keyword == Keyword::END {
-                        break;
-                    }
-                }
+            match self.peek_token().token {
+                Token::EOF => break,
+
+                // end of statement
+                Token::Word(word) if word.keyword == Keyword::END => break,
+                _ => {}
             }
 
             if expecting_statement_delimiter {
@@ -384,9 +381,7 @@ impl<'a> Parser<'a> {
     /// # }
     /// ```
     pub fn parse_sql(dialect: &dyn Dialect, sql: &str) -> Result<Vec<Statement>, ParserError> {
-        Parser::new(dialect)
-            .try_with_sql(sql)?
-            .parse_statements(false)
+        Parser::new(dialect).try_with_sql(sql)?.parse_statements()
     }
 
     /// Parse a single top-level statement (such as SELECT, INSERT, CREATE, etc.),
@@ -7077,7 +7072,7 @@ impl<'a> Parser<'a> {
         let params = self.parse_optional_procedure_parameters()?;
         self.expect_keyword(Keyword::AS)?;
         self.expect_keyword(Keyword::BEGIN)?;
-        let statements = self.parse_statements(true)?;
+        let statements = self.parse_statements()?;
         self.expect_keyword(Keyword::END)?;
         Ok(Statement::CreateProcedure {
             name,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -84,7 +84,7 @@ impl TestedDialects {
         self.one_of_identical_results(|dialect| {
             self.new_parser(dialect)
                 .try_with_sql(sql)?
-                .parse_statements(false)
+                .parse_statements()
         })
         // To fail the `ensure_multiple_dialects_are_tested` test:
         // Parser::parse_sql(&**self.dialects.first().unwrap(), sql)

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -6907,7 +6907,7 @@ fn parse_deeply_nested_expr_hits_recursion_limits() {
     let res = Parser::new(&dialect)
         .try_with_sql(&sql)
         .expect("tokenize to work")
-        .parse_statements(false);
+        .parse_statements();
 
     assert_eq!(res, Err(ParserError::RecursionLimitExceeded));
 }
@@ -6922,7 +6922,7 @@ fn parse_deeply_nested_subquery_expr_hits_recursion_limits() {
     let res = Parser::new(&dialect)
         .try_with_sql(&sql)
         .expect("tokenize to work")
-        .parse_statements(false);
+        .parse_statements();
 
     assert_eq!(res, Err(ParserError::RecursionLimitExceeded));
 }
@@ -6938,7 +6938,7 @@ fn parse_with_recursion_limit() {
     let res = Parser::new(&dialect)
         .try_with_sql(&sql)
         .expect("tokenize to work")
-        .parse_statements(false);
+        .parse_statements();
 
     assert!(matches!(res, Ok(_)), "{res:?}");
 
@@ -6947,7 +6947,7 @@ fn parse_with_recursion_limit() {
         .try_with_sql(&sql)
         .expect("tokenize to work")
         .with_recursion_limit(20)
-        .parse_statements(false);
+        .parse_statements();
 
     assert_eq!(res, Err(ParserError::RecursionLimitExceeded));
 
@@ -6956,7 +6956,7 @@ fn parse_with_recursion_limit() {
         .try_with_sql(&sql)
         .expect("tokenize to work")
         .with_recursion_limit(50)
-        .parse_statements(false);
+        .parse_statements();
 
     assert!(matches!(res, Ok(_)), "{res:?}");
 }

--- a/tests/sqlparser_mssql.rs
+++ b/tests/sqlparser_mssql.rs
@@ -58,6 +58,13 @@ fn parse_mssql_delimited_identifiers() {
 #[test]
 fn parse_create_procedure() {
     let sql = "CREATE OR ALTER PROCEDURE test (@foo INT, @bar VARCHAR(256)) AS BEGIN SELECT 1 END";
+
+    #[cfg(feature = "bigdecimal")]
+    let one = Value::Number(bigdecimal::BigDecimal::from(1), false);
+
+    #[cfg(not(feature = "bigdecimal"))]
+    let one = Value::Number("1".to_string(), false);
+
     assert_eq!(
         ms().verified_stmt(sql),
         Statement::CreateProcedure {
@@ -72,10 +79,7 @@ fn parse_create_procedure() {
                 body: Box::new(SetExpr::Select(Box::new(Select {
                     distinct: None,
                     top: None,
-                    projection: vec![SelectItem::UnnamedExpr(Expr::Value(Value::Number(
-                        "1".to_string(),
-                        false
-                    )))],
+                    projection: vec![SelectItem::UnnamedExpr(Expr::Value(one))],
                     into: None,
                     from: vec![],
                     lateral_views: vec![],


### PR DESCRIPTION
Proposed changes to https://github.com/sqlparser-rs/sqlparser-rs/pull/900:
1. Fix the handling of `END` statements
2. Make it compile with all features
3. Make it compile without std (needs to avoid the use of `format!()`